### PR TITLE
feat: Add support for global registration functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ import {MJMLCustomComponent} from "mjml-custom-component-decorator";
         }
     },
     allowedParentTags: ["mj-column"],
-    registerDependencies,
-    registerComponent,
 })
 export class MyCustomComponent extends BodyComponent {
     render() {

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,8 +1,6 @@
 import mjml2html from "mjml";
 import {BodyComponent} from "mjml-core";
 import {MJMLCustomComponent} from "../src";
-import {registerComponent} from "mjml-core";
-import {registerDependencies} from "mjml-validator";
 
 @MJMLCustomComponent({
     tag: "custom-text",
@@ -15,9 +13,7 @@ import {registerDependencies} from "mjml-validator";
             type: "color"
         }
     },
-    allowedParentTags: ["mj-column"],
-    registerDependencies,
-    registerComponent,
+    allowedParentTags: ["mj-column"]
 })
 export class CustomText extends BodyComponent {
     render() {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "mjml-custom-component-decorator",
   "version": "0.0.0-development",
   "description": "TypeScript decorator for MJML custom components",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "cjs/index.js",
+  "types": "cjs/types/index.d.ts",
   "scripts": {
     "test": "jest",
-    "build": "npm run build:clean && npm run build:tsc && npm run build:copy-files",
+    "build": "npm run build:clean && npm run build:esm && npm run build:cjs && npm run build:copy-files",
     "build:clean": "rm -rf dist/ || true && mkdir -p dist/",
-    "build:tsc": "tsc -p tsconfig.cjs.json",
-    "build:copy-files": "cp -t ./dist/ LICENSE README.md package.json src/mjml-validator.d.ts",
+    "build:esm": "tsc -p tsconfig.esm.json && mv dist/esm/index.js dist/esm/index.mjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:copy-files": "cp -t ./dist/ LICENSE README.md package.json",
     "semantic-release": "semantic-release --branches main",
     "release": "npm run build && cd dist && npm i && npm run semantic-release"
   },
@@ -20,6 +21,18 @@
   },
   "bugs": {
     "url": "https://github.com/timo-reymann/mjml-custom-component-decorator/issuess"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./esm/types/index.d.ts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./cjs/types/index.d.ts",
+        "default": "./cjs/index.js"
+      }
+    }
   },
   "homepage": "https://github.com/timo-reymann/mjml-custom-component-decorator#readme",
   "license": "MIT",

--- a/src/CustomComponentOptions.ts
+++ b/src/CustomComponentOptions.ts
@@ -24,22 +24,4 @@ export interface CustomComponentOptions {
      * Tag for element
      */
     tag: string;
-
-    /**
-     * registerDependencies function from mjml-validator
-     *
-     *
-     * Since bundling would use the wrong validator context and therefore validation won't work you need to specify it
-     */
-    registerDependencies : (payload: { [k: string]: string[] }) => void
-
-    /**
-     * registerComponent function from mjml-core
-     *
-     * If not provided, component wont be registered
-     *
-     * Since bundling would use the wrong validator core context and therefore validation won't work you need to specify it
-     * @param ComponentClass
-     */
-    registerComponent ?: (ComponentClass: typeof BodyComponent) => void
 }

--- a/src/MJMLCustomComponent.ts
+++ b/src/MJMLCustomComponent.ts
@@ -1,5 +1,7 @@
 import {BodyComponent} from "mjml-core"
 import {CustomComponentOptions} from "./CustomComponentOptions";
+import {registerComponent} from "mjml-core";
+import {registerDependencies} from "mjml-validator";
 // Helper type for anonymous objects
 export type AnonymousObject = { [k: string]: any }
 
@@ -45,11 +47,9 @@ export function MJMLCustomComponent(options: CustomComponentOptions) {
             dependencies[allowedParentTag] = [componentName]
         }
 
-        options.registerDependencies(dependencies)
+        registerDependencies(dependencies)
+        registerComponent(target)
 
-        if (options.registerComponent) {
-            options.registerComponent(target)
-        }
 
         return target
     }

--- a/test/MJMLCustComponent.test.ts
+++ b/test/MJMLCustComponent.test.ts
@@ -1,12 +1,15 @@
 import {MJMLCustomComponent} from "../src";
-import {registerComponent} from "mjml-core";
+import {BodyComponent, registerComponent} from "mjml-core";
 import {registerDependencies} from "mjml-validator";
+import mjml2html from "mjml";
 
 function _createValidDecorator() {
     return MJMLCustomComponent({
         tag: "mjml-custom-component",
         endingTag: false,
-        allowedParentTags: [],
+        allowedParentTags: [
+            "mj-column"
+        ],
         attributes: {
             foo: {
                 type: 'string',
@@ -19,9 +22,13 @@ function _createValidDecorator() {
 }
 
 function _createDummyComponent(): any {
-    return {
-        getTagName() {
-            return "foo-bar"
+    return new class extends BodyComponent {
+        constructor() {
+            super({});
+        }
+
+        render(): string {
+            return this.renderMJML(` <mj-text>Test </mj-text>`)
         }
     }
 }

--- a/test/MJMLCustComponent.test.ts
+++ b/test/MJMLCustComponent.test.ts
@@ -1,6 +1,5 @@
 import {MJMLCustomComponent} from "../src";
-import {BodyComponent, registerComponent} from "mjml-core";
-import {registerDependencies} from "mjml-validator";
+import {BodyComponent} from "mjml-core";
 import mjml2html from "mjml";
 
 function _createValidDecorator() {
@@ -16,8 +15,6 @@ function _createValidDecorator() {
                 default: 'bar'
             }
         },
-        registerComponent,
-        registerDependencies
     })
 }
 
@@ -39,8 +36,6 @@ describe("Test MJMLCustomCpomponent", () => {
             tag: "",
             allowedParentTags: [],
             attributes: {},
-            registerComponent,
-            registerDependencies
         })
         expect(result).not.toBeNull()
         expect(typeof result).toBe('function')

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -3,7 +3,7 @@ import {BodyComponent} from "mjml-core";
 import {MJMLCustomComponent} from "../src";
 
 describe("integration test", () => {
-    it("should register properly", () => {
+    it("should register properly and allow rendering seemlessly", () => {
         @MJMLCustomComponent({
             tag: "custom-text",
             attributes: {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,50 @@
+import mjml2html from "mjml";
+import {BodyComponent} from "mjml-core";
+import {MJMLCustomComponent} from "../src";
+
+describe("integration test", () => {
+    it("should register properly", () => {
+        @MJMLCustomComponent({
+            tag: "custom-text",
+            attributes: {
+                text: {
+                    type: 'string',
+                    default: 'Hello World'
+                },
+                'text-color': {
+                    type: "color"
+                }
+            },
+            allowedParentTags: ["mj-column"]
+        })
+         class CustomText extends BodyComponent {
+            render() {
+                return this.renderMJML(`
+            <mj-text align="center" color="${this.getAttribute('text-color')}">
+                ${this.getAttribute("text")}
+            </mj-text>`
+                )
+            }
+        }
+
+        const result = mjml2html(`
+  <mjml>
+    <mj-body>
+      <mj-section>
+        <mj-column>
+            <custom-text text-color="blue" text="Foo" />
+            <mj-divider />            
+            <custom-text text="Bar"></custom-text>
+            <mj-divider />
+            <custom-text text="Baz" />
+        </mj-column>
+      </mj-section>
+    </mj-body>
+  </mjml>
+`, {
+            validationLevel: 'strict'
+        })
+        expect(result.errors.length).toBe(0)
+        expect(result.html).toBeDefined()
+    })
+})

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist",
-    "target": "es2020",
-    "declarationMap": true
+    "lib": ["ES6", "DOM"],
+    "target": "ES6",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declarationDir": "dist/cjs/types"
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist/esm",
+    "declarationDir": "dist/esm/types"
+  }
+}


### PR DESCRIPTION
## Description
Previously there were problems with the global registration functions not working in some sencarios, which required to add a ugly workaround passing the methods in.

After revisiting the typescript config and rebuilding it (again), it seems to work in all of these now.
